### PR TITLE
Remove comments from lift planner script

### DIFF
--- a/Lift_planner_v1p5a
+++ b/Lift_planner_v1p5a
@@ -73,20 +73,20 @@ class LiftPlannerV1P5:
        self.beam_width = beam_width
        self.early_temp_threshold = early_temp_threshold
        self._mode_B_active = False
-       # Track the step number of the most recent drop to TEMP.  This is used to avoid
-       # immediately offloading items that have just been stashed into TEMP in the same
-       # step.  A value of -1 indicates no drops have occurred yet.
+                                                                                      
+                                                                                       
+                                                                   
        self.last_temp_drop_step: int = -1
-       # When a drop to TEMP occurs, set this flag to True.  The next call to
-       # maybe_early_temp_return will clear the flag and skip any early offload from
-       # TEMP.  This avoids the pathological case where items are returned to TEMP
-       # and immediately offloaded back to a source in the same extraction sequence.
+                                                                             
+                                                                                    
+                                                                                  
+                                                                                    
        self.just_dropped_to_temp: bool = False
 
    def clone(self):
        return copy.deepcopy(self)
 
-   # --- Logging helpers ---
+                            
    def _record(self, action: str, location: str, count: int, items: List[Sat], note: str = ""):
        self.step_counter += 1
        self.log.append(Action(self.step_counter, action, location, count, [x.sat for x in items], note))
@@ -97,7 +97,7 @@ class LiftPlannerV1P5:
 
    def get_log_dataframe_compact(self) -> pd.DataFrame:
        rows = []
-       carry = None  # type: Optional[Action]
+       carry = None                          
        for a in self.log:
            if a.action == "pick":
                if carry and carry.action == "pick" and carry.location == a.location:
@@ -147,7 +147,7 @@ class LiftPlannerV1P5:
            "hand_count": len(self.hand),
            "source_lengths": {s.name: len(s.items) for s in self.sources},
        }
-       # Add final stack orders for verification.
+                                                 
        summary["final_dest_top_to_bottom"] = [sat.sat for sat in self.dest.items]
        summary["final_source_stacks_top_to_bottom"] = {
            s.name: [sat.sat for sat in s.items] for s in self.sources
@@ -155,7 +155,7 @@ class LiftPlannerV1P5:
        summary["final_temp_top_to_bottom"] = [sat.sat for sat in self.temp.items]
        return summary
 
-   # --- Target-set helpers ---
+                               
    def _remaining_targets(self) -> Set[str]:
        delivered = {x.sat for x in self.dest.items}
        return {t for t in self.target_ids if t not in delivered}
@@ -167,7 +167,7 @@ class LiftPlannerV1P5:
        rem = self._remaining_targets()
        return any(s.sat in rem for s in stack.items)
 
-   # --- Heuristics for temp returns ---
+                                        
    def _score_offload_stack(self, stack: 'StackState', batch_size: int):
        """
        Compute a score for offloading a batch of TEMP items to a given stack.  Lower scores
@@ -178,42 +178,42 @@ class LiftPlannerV1P5:
        the batch or when the depth is below a threshold.  Otherwise, prefer stacks with
        more free space and deeper remaining targets.
        """
-       # If offloading would overflow the stack, forbid this candidate by returning huge
+                                                                                        
        if len(stack.items) + batch_size > stack.cap:
            return (10**9, 0, 0)
-       # Determine if this stack still contains any remaining target
+                                                                    
        has_any = int(self._stack_has_any_remaining_target(stack))
-       # Find the depth (index) of the first remaining target in this stack
+                                                                           
        depth = None
        rem = self._remaining_targets()
        for i, sat in enumerate(stack.items):
            if sat.sat in rem:
                depth = i
                break
-       # If the next target is very close to the top (depth is small), avoid offloading here.
-       # We use a threshold based on the hand capacity and batch_size: if the remaining target
-       # would be within the current offload batch or within a small constant (3) above it,
-       # we penalize heavily.  This helps prevent the situation where items are returned to
-       # this stack only to be peeled again immediately afterwards.
+                                                                                             
+                                                                                              
+                                                                                           
+                                                                                           
+                                                                   
        if depth is not None:
-           # Determine threshold: the number of items we plan to offload plus a small margin.
-           # Using min(batch_size, hand_capacity) ensures we only penalize when the target
-           # would be buried within or just below the offloaded run.
+                                                                                             
+                                                                                          
+                                                                    
            threshold = min(batch_size, self.hand_capacity)
-           # Add a small margin to catch cases where the target is only a few items below
-           # the offloaded region.  A margin of 2 provides a good balance between avoiding
-           # immediate re-peeling and still utilizing available stacks when necessary.
+                                                                                         
+                                                                                          
+                                                                                      
            margin = 2
            if depth < threshold + margin:
-               # Penalize extremely; this makes this stack a last resort for offloading
+                                                                                       
                return (10**9, 0, 0)
-       # Compute a softer penalty based on depth; deeper targets are less likely to require
-       # immediate peeling, so they receive a smaller penalty.  If there is no remaining
-       # target in this stack, depth_pen is zero.
+                                                                                           
+                                                                                        
+                                                 
        depth_pen = 0 if depth is None else max(0, 10 - depth)
-       # More space is better: we use negative space so that larger space yields a smaller
-       # overall score.  We also use negative stack size to break ties by preferring
-       # shorter stacks when space is equal.
+                                                                                          
+                                                                                    
+                                            
        space = stack.space_left()
        return (has_any * 100 + depth_pen * 5, -space, -len(stack.items))
 
@@ -235,20 +235,20 @@ class LiftPlannerV1P5:
            The chosen StackState, or None if no valid offload site exists.
        """
        def allowed(s: 'StackState') -> bool:
-           # Exclude the specified stack
+                                        
            if exclude is not None and s is exclude:
                return False
-           # Cannot exceed capacity
+                                   
            if len(s.items) + batch_size > s.cap:
                return False
-           # Cannot drop onto a remaining target
+                                                
            if self._is_remaining_target(s.top()):
                return False
-           # Avoid dropping onto a stack whose top is a cleared satellite.
+                                                                          
            if s.top() and s.top().cleared:
                return False
-           # If a cleared satellite exists deeper in this stack, ensure that
-           # adding this batch will not bury it under 7 or more blockers.
+                                                                            
+                                                                         
            future_idx = next((i for i, sat in enumerate(s.items) if sat.cleared), None)
            if future_idx is not None and future_idx + batch_size >= 7:
                return False
@@ -256,23 +256,23 @@ class LiftPlannerV1P5:
        candidates = [s for s in self.sources if allowed(s)]
        if not candidates:
            return None
-       # Choose the candidate with the lowest score according to _score_offload_stack
+                                                                                     
        candidates.sort(key=lambda s: self._score_offload_stack(s, batch_size))
        return candidates[0]
 
    def _ensure_temp_space(self, needed: int):
        while self.temp.space_left() < needed:
-           # Determine which source stacks can safely receive offloaded items.
+                                                                              
            def safe_drop_target(s: 'StackState') -> bool:
-               # Cannot offload to full stacks or onto a remaining target.
+                                                                          
                if s.space_left() <= 0:
                    return False
                if self._is_remaining_target(s.top()):
                    return False
-               # Avoid dropping onto a top cleared sat
+                                                      
                if s.top() and s.top().cleared:
                    return False
-               # Ensure that adding a batch won't bury an existing cleared sat under >=7 blockers
+                                                                                                 
                max_n = min(self.hand_capacity, len(self.temp.items), s.space_left())
                future_idx = next((i for i, sat in enumerate(s.items) if sat.cleared), None)
                if future_idx is not None and future_idx + max_n >= 7:
@@ -281,42 +281,42 @@ class LiftPlannerV1P5:
 
            safe = [s for s in self.sources if safe_drop_target(s)]
            if not safe:
-               # If no safe stack exists, try to clear top targets to create space
+                                                                                  
                tops = [s for s in self.sources if self._is_remaining_target(s.top())]
                if not tops:
-                   # In Mode B, we can also move cleared tops directly to DEST
+                                                                              
                    if self._mode_B_active:
                        cleared_tops = [s for s in self.sources if s.top() and s.top().cleared]
                        if cleared_tops:
                            self._pick(cleared_tops[0], 1, note="Free stack by moving top cleared to DEST")
                            self._drop(self.dest, 1, note="Drop cleared top to DEST (Mode B)")
                            continue
-                   # If even that fails, deadlock; no space can be freed
+                                                                        
                    raise RuntimeError("Deadlock: no safe stacks and no top targets to clear.")
-               # Clear a top target to make a safe stack
+                                                        
                self._pick(tops[0], 1, note="Free stack top target to create safe offload site")
                self._drop(self.dest, 1, note="Clear top target to DEST")
                continue
 
-           # Select the best stack to offload into based on scoring
+                                                                   
            safe.sort(key=lambda s: self._score_offload_stack(s,
                                                             min(self.hand_capacity, len(self.temp.items), s.space_left())))
            target_stack = safe[0]
            move_n = min(self.hand_capacity, len(self.temp.items), target_stack.space_left())
            if move_n == 0:
                break
-           # Free space by moving a batch from TEMP to a safe source.  Use the unified
-           # _pick/_drop helpers so that the single-pick/single-drop contract is
-           # respected even during this maintenance operation.
+                                                                                      
+                                                                                
+                                                              
            self._pick(self.temp, move_n, note="Freeing TEMP space (early offload)")
            self._drop(target_stack, move_n, note="Return from TEMP to source (batched)")
 
    def maybe_early_temp_return(self):
-       # Avoid immediately offloading items that were just dropped to TEMP.  When this flag
-       # is set, clear it and return without performing any early offload.  This allows
-       # freshly stashed blockers to remain in TEMP for at least one extraction cycle.
+                                                                                           
+                                                                                       
+                                                                                      
        if self.just_dropped_to_temp:
-           # Reset the flag and skip early temp return
+                                                      
            self.just_dropped_to_temp = False
            return
        if len(self.temp.items) >= self.early_temp_threshold:
@@ -331,13 +331,13 @@ class LiftPlannerV1P5:
                    best_stack = s
            if best_stack:
                move_n = min(self.hand_capacity, len(self.temp.items), best_stack.space_left())
-               # Move a batch from TEMP back to a source stack using unified pick/drop
-               # helpers.  This preserves ordering and satisfies the unified-mode
-               # requirement of one pick followed by one drop.
+                                                                                      
+                                                                                 
+                                                              
                self._pick(self.temp, move_n, note="Proactive TEMP reduction")
                self._drop(best_stack, move_n, note="Early temp return (reduces future costs)")
 
-   # --- Utility helpers ---
+                            
    def _first_remaining_target_in_stack(self, stack: 'StackState'):
        rem = self._remaining_targets()
        for idx, sat in enumerate(stack.items):
@@ -360,17 +360,17 @@ class LiftPlannerV1P5:
        cands = self._candidate_stacks()
        if not cands:
            raise RuntimeError("No candidates found.")
-       # If only one candidate, no need for complex heuristics
+                                                              
        if len(cands) == 1:
            return cands[0]
-       # --- Heuristic selection for Mode A with deeper run consideration ---
-       # Build candidate information: for each stack, compute the index of the first remaining
-       # target (first_idx), all contiguous segments of remaining targets (with their start
-       # positions), the length of the largest contiguous run, and the starting index of that run.
-       candidate_info = []  # tuples: (stack, first_idx, reachable, max_run_len, total_targets, segments_cnt, largest_start)
+                                                                             
+                                                                                              
+                                                                                           
+                                                                                                  
+       candidate_info = []                                                                                                  
        rem = self._remaining_targets()
        for s in cands:
-           # Find the index of the first remaining target in this stack
+                                                                       
            first_idx = None
            for idx, sat in enumerate(s.items):
                if sat.sat in rem:
@@ -379,10 +379,10 @@ class LiftPlannerV1P5:
            if first_idx is None:
                continue
            reachable = first_idx <= self.hand_capacity
-           # Compute contiguous segments of remaining targets along with their start offsets
+                                                                                            
            items_after = s.items[first_idx:]
            flags = [(item.sat in rem) for item in items_after]
-           segments: List[Tuple[int, int]] = []  # (start_offset, length)
+           segments: List[Tuple[int, int]] = []                          
            i = 0
            while i < len(flags):
                if flags[i]:
@@ -393,32 +393,32 @@ class LiftPlannerV1P5:
                else:
                    i += 1
            if segments:
-               # Choose the largest contiguous run; tie-break on shallowest start
+                                                                                 
                segments.sort(key=lambda x: (-x[1], x[0]))
                largest_start, max_run_len = segments[0]
                total_targets = sum(l for _, l in segments)
                segments_cnt = len(segments)
            else:
-               # Should not happen: no contiguous segments
+                                                          
                largest_start, max_run_len = 0, 1
                total_targets = 1
                segments_cnt = 1
            candidate_info.append((s, first_idx, reachable, max_run_len, total_targets, segments_cnt, largest_start))
        if not candidate_info:
-           # Fallback: use first candidate if none computed
+                                                           
            return cands[0]
-       # Evaluate each candidate by an approximate cost to reach and deliver its largest run
-       # Compute depth to largest run: first_idx + largest_start
-       scored: List[Tuple[float, int, int, Tuple]] = []  # (cost, -max_run_len, first_idx, candidate)
+                                                                                            
+                                                                
+       scored: List[Tuple[float, int, int, Tuple]] = []                                              
        for info in candidate_info:
            stack_c, first_idx, reachable_c, max_run_len, total_targets, segments_cnt, largest_start = info
            idx_large = first_idx + largest_start
-           # Cost to peel blockers and deliver largest run: 2 * (ceil(idx_large/hand) + ceil(max_run_len/hand)) / max_run_len
+                                                                                                                             
            lifts_blockers = math.ceil(idx_large / self.hand_capacity)
            lifts_goods = math.ceil(max_run_len / self.hand_capacity)
            cost = (lifts_blockers + lifts_goods) * 2 / max_run_len
            scored.append((cost, -max_run_len, first_idx, info))
-       # Sort candidates by cost, then by longer max_run_len, then by shallower first_idx
+                                                                                         
        scored.sort(key=lambda x: (x[0], x[1], x[2]))
        best_info = scored[0][3]
        best_stack = best_info[0]
@@ -470,7 +470,7 @@ class LiftPlannerV1P5:
        dest_set = {x.sat for x in self.dest.items}
        runs: List[Tuple[float,int,int,'StackState']] = []
        for s in self.sources:
-           # build cleared flags for sats not yet delivered
+                                                           
            flags = [(sat.cleared and sat.sat not in dest_set) for sat in s.items]
            i = 0
            while i < len(flags):
@@ -486,7 +486,7 @@ class LiftPlannerV1P5:
                    runs.append((cost, start, length, s))
                else:
                    i += 1
-       # Sort by cost then by shallower start
+                                             
        runs.sort(key=lambda x: (x[0], x[1]))
        selected: Set[str] = set()
        for cost, start, length, s in runs:
@@ -520,8 +520,8 @@ class LiftPlannerV1P5:
                break
        return cnt
 
-   # --- Core extraction step for Mode A ---
-   # --- Modes ---
+                                            
+                  
    def plan_mode_A(self):
        """
        Unified Mode A: deliver remaining target IDs using a deeper lookâahead similar
@@ -534,60 +534,60 @@ class LiftPlannerV1P5:
        """
        if not self.target_ids:
            raise AssertionError("Mode A requires target_ids to be provided.")
-       # Verify that all targets exist in the source stacks
+                                                           
        all_ids = {sat.sat for s in self.sources for sat in s.items}
        missing = [t for t in self.target_ids if t not in all_ids]
        if missing:
            raise AssertionError(f"Targets not found in stacks: {missing}")
-       # Continue until all targets have been delivered to the destination
-       # Note: use a while loop rather than recursion to support deep lookâahead
+                                                                          
+                                                                                  
        while True:
            remaining_targets = self._remaining_targets()
            if not remaining_targets:
                break
-           # Determine how many targets have been delivered so far
+                                                                  
            delivered = len({x.sat for x in self.dest.items if x.sat in self.target_ids})
            remaining = len(self.target_ids) - delivered
            if remaining <= 0:
                break
-           # --- Step 1: Identify the best topârun of remaining targets across all stacks ---
+                                                                                               
            best_top_run = 0
            best_top_stack: Optional[StackState] = None
            for s in self.sources:
-               # Skip stacks with no remaining targets
+                                                      
                if not self._stack_has_any_remaining_target(s):
                    continue
-               # Compute the length of the contiguous run of remaining targets at the top
+                                                                                         
                run_len = self._contiguous_top_remaining_targets(s)
                if run_len > best_top_run:
                    best_top_run = run_len
                    best_top_stack = s
-           # Compute the cost of delivering this top run.  If run is longer than
-           # the hand capacity, multiple lifts will be required.
+                                                                                
+                                                                
            if best_top_run > 0:
                lifts_top = math.ceil(best_top_run / self.hand_capacity)
                cost_top = 2 * lifts_top / best_top_run
            else:
                cost_top = float('inf')
-           # --- Step 2: Identify the largest contiguous runs of remaining targets within each stack ---
-           candidates_info: List[Tuple[StackState, int, int]] = []  # (stack, idx_large, run_len_large)
-           # Build a set of currently delivered items to avoid recounting in candidate selection
+                                                                                                        
+           candidates_info: List[Tuple[StackState, int, int]] = []                                     
+                                                                                                
            dest_set = {x.sat for x in self.dest.items}
            rem_set = remaining_targets
            for s in self.sources:
-               # Skip stacks with no remaining targets
+                                                      
                if not self._stack_has_any_remaining_target(s):
                    continue
-               # Build a boolean flag list for each item: True if it's a remaining target
+                                                                                         
                flags = [(sat.sat in rem_set) for sat in s.items]
-               # Find the index of the first remaining target
+                                                             
                try:
                    first_idx = flags.index(True)
                except ValueError:
                    continue
-               # Consider only the sublist from the first target downward
+                                                                         
                items_after = flags[first_idx:]
-               # Identify all contiguous segments of True values and record their start offsets and lengths
+                                                                                                           
                segments: List[Tuple[int, int]] = []
                i = 0
                while i < len(items_after):
@@ -600,19 +600,19 @@ class LiftPlannerV1P5:
                        i += 1
                if not segments:
                    continue
-               # Choose the largest contiguous run; on tie, use the shallowest start
+                                                                                    
                segments.sort(key=lambda x: (-x[1], x[0]))
                largest_start, run_len_large = segments[0]
-               # Compute the absolute index of the start of this large run in the stack
+                                                                                       
                idx_large = first_idx + largest_start
-               # We only consider peeling to reach runs that are not at the very top
+                                                                                    
                if idx_large > 0:
                    candidates_info.append((s, idx_large, run_len_large))
-           # If candidates exist, compute their cost per target for peeling and delivering
+                                                                                          
            best_large_cost = float('inf')
            best_cand: Optional[Tuple[StackState, int, int]] = None
            if candidates_info:
-               # Compute approximate cost ratio for peeling blockers and delivering the largest run
+                                                                                                   
                cost_candidates: List[Tuple[float, int, Tuple[StackState, int, int]]] = []
                for stack_c, idx_large, run_len_large in candidates_info:
                    lifts_blockers = math.ceil(idx_large / self.hand_capacity)
@@ -620,39 +620,39 @@ class LiftPlannerV1P5:
                    actions = 2 * (lifts_blockers + lifts_goods)
                    cost = actions / run_len_large if run_len_large > 0 else float('inf')
                    cost_candidates.append((cost, idx_large, (stack_c, idx_large, run_len_large)))
-               # Select candidate with lowest cost; break ties by shallower depth
+                                                                                 
                cost_candidates.sort(key=lambda x: (x[0], x[1]))
                best_large_cost, _, best_cand = cost_candidates[0]
-           # --- Step 3: Decide whether to deliver a topârun or peel to a deeper run ---
+                                                                                          
            if best_top_run > 0 and cost_top <= best_large_cost:
-               # Deliver the contiguous top run of targets from the best stack
+                                                                              
                take = min(best_top_run, self.hand_capacity, remaining)
-               # Note: we use _pick and _drop directly to enforce unified single pick/drop
+                                                                                          
                self._pick(best_top_stack, take, note=f"Mode A unified: pick {take} target(s) from top")
                self._drop(self.dest, take, note=f"Mode A unified: deliver {take} target(s) to DEST")
-               # Update delivered count automatically via dest stack
+                                                                    
                self.maybe_early_temp_return()
                continue
-           # Otherwise, peel blockers (and intermediate targets) to reach the large run
+                                                                                       
            if best_cand is not None:
                stack_c, idx_large, run_len_large = best_cand
-               # Determine how many blockers to peel: the depth of the large run
+                                                                                
                peel_n = idx_large
-               # Peel up to hand capacity or the full depth, whichever is smaller
+                                                                                 
                chunk = min(self.hand_capacity, peel_n)
-               # Identify an offload destination for the peeled items
+                                                                     
                offload = self._choose_offload_stack(chunk, exclude=stack_c)
                if offload is None:
-                   # No safe source available; use TEMP (expand it if needed)
+                                                                             
                    if self.temp.space_left() < chunk:
                        self._ensure_temp_space(chunk)
                    offload = self.temp
-               # Pick and offload blockers/targets from the chosen stack
+                                                                        
                self._pick(stack_c, chunk, note="Mode A unified: peel blockers")
                self._drop(offload, chunk, note=f"Mode A unified: offload to {offload.name}")
                self.maybe_early_temp_return()
                continue
-                       # --- TEMP recovery path: if no source has remaining targets but TEMP does, deliver/unwind TEMP ---
+                                                                                                                          
            if not self._candidate_stacks() and self._stack_has_any_remaining_target(self.temp):
                temp_run = self._contiguous_top_remaining_targets(self.temp)
                if temp_run > 0:
@@ -670,14 +670,14 @@ class LiftPlannerV1P5:
                            self._drop(offload_site, move_n, note="Unwind TEMP (to enable Mode A candidates)")
                            self.maybe_early_temp_return()
                            continue
-# Fallback: no large run candidates and no top run; use the original heuristics
-           # Fall back to beam search when deeper lookâahead cannot find a candidate
+                                                                               
+                                                                                      
            if not self._remaining_targets():
                break
-           # Use existing beam search heuristics for tough cases
+                                                                
            stack = self._beam_choose_next_stack()
            self._extract_one_from_stack(stack)
-       # After all targets delivered, return items from TEMP to sources
+                                                                       
        self.return_all_temp()
 
    def return_all_temp(self):
@@ -698,9 +698,9 @@ class LiftPlannerV1P5:
            self._pick(self.temp, move_n, note="Final cleanup: empty TEMP")
            self._drop(best_stack, move_n, note="Return TEMP to source")
 
-   # === Unified single-pick/single-drop overrides ===
-   # Enforce: one pick and one drop per lift; picks come from a single stack;
-   # drop goes to exactly one destination (DEST, TEMP, or a safe source).
+                                                      
+                                                                             
+                                                                         
 
    def _ensure_unified_state(self):
        if not hasattr(self, 'unified_mode'):
@@ -709,44 +709,44 @@ class LiftPlannerV1P5:
            self._lift_in_progress = False
 
    def _pick(self, stack: 'StackState', k: int, note: str = ""):
-       # Unified guard: only one pick per lift
+                                              
        self._ensure_unified_state()
        if getattr(self, 'unified_mode', False):
            if self._lift_in_progress:
                raise AssertionError("Unified mode: cannot perform multiple picks in a single lift.")
            if len(self.hand) != 0:
-               # Any residual in hand implies previous drop wasn't completed; disallow
+                                                                                      
                raise AssertionError("Unified mode: hand must be empty before a pick.")
            self._lift_in_progress = True
-       # Original logic
+                       
        assert 1 <= k <= len(stack.items), "Pick exceeds available."
        assert len(self.hand) + k <= self.hand_capacity, "Hand over capacity."
-       batch = stack.pop_batch(k)  # top-to-bottom
+       batch = stack.pop_batch(k)                 
        self.hand.extend(batch)
        self._record("pick", stack.name, k, batch, note)
 
    def _drop(self, stack: 'StackState', k: int, note: str = ""):
-       # Unified guard: exactly one drop per lift, must drop entire hand
+                                                                        
        self._ensure_unified_state()
        if getattr(self, 'unified_mode', False):
            if not self._lift_in_progress:
                raise AssertionError("Unified mode: drop without a prior pick.")
            if k != len(self.hand):
                raise AssertionError("Unified mode: must drop all lifted sats in a single drop.")
-       # Original safety checks
+                               
        assert 1 <= k <= len(self.hand), "Drop exceeds hand content."
        batch_top_to_bottom = self.hand[-k:][::-1]
        if stack is not self.dest:
            assert len(stack.items) + k <= stack.cap, f"Drop would exceed cap of {stack.name}"
            if stack is not self.temp and self._is_remaining_target(stack.top()):
                raise AssertionError(f"Cannot drop onto {stack.name}: top is a remaining target.")
-           # Mode B originally disallowed dropping onto stacks whose top item was a
-           # cleared satellite.  Removing this restriction keeps Mode B's behaviour
-           # aligned with Mode A and avoids extra cleanup lifts.
+                                                                                   
+                                                                                   
+                                                                
        stack.push_batch(batch_top_to_bottom)
        del self.hand[-k:]
        self._record("drop", stack.name, k, batch_top_to_bottom, note)
-       # Unified guard: close the lift
+                                      
        if getattr(self, 'unified_mode', False):
            self._lift_in_progress = False
        if stack is self.temp:
@@ -754,7 +754,7 @@ class LiftPlannerV1P5:
 
    def _extract_one_from_stack(self, stack: 'StackState') -> bool:
        """Unified override for Mode A: one pick and one drop per lift."""
-       # If stack top already has remaining targets, deliver them in one lift
+                                                                             
        top_run = self._contiguous_top_remaining_targets(stack)
        if top_run > 0:
            take = min(top_run, self.hand_capacity)
@@ -766,11 +766,11 @@ class LiftPlannerV1P5:
        if frt is None:
            return False
        idx, _ = frt
-       # Peel blockers only (no mixed pick), offload in one drop
+                                                                
        chunk = min(self.hand_capacity, idx)
        if chunk <= 0:
            return False
-       # Ensure we have somewhere to offload; prefer a safe source
+                                                                  
        offload = self._choose_offload_stack(chunk, exclude=stack)
        if offload is None:
            if self.temp.space_left() < chunk:
@@ -791,7 +791,7 @@ class LiftPlannerV1P5:
        self._mode_B_request_count = count
        delivered = len([x for x in self.dest.items if x.cleared])
        while True:
-           # Dynamic goal: don't exceed available cleared sats
+                                                              
            dest_set = {x.sat for x in self.dest.items}
            available_cleared = sum(
                1 for s in self.sources for sat in s.items
@@ -801,13 +801,13 @@ class LiftPlannerV1P5:
            if remaining <= 0:
                break
 
-           # 1) Determine candidate stacks by analysing the largest contiguous cleared run in each stack
-           candidates_info: List[Tuple[StackState, int, int]] = []  # (stack, idx_large, run_len_large)
+                                                                                                        
+           candidates_info: List[Tuple[StackState, int, int]] = []                                     
            for s in self.sources:
-               # Compute flags for cleared sats not yet delivered
+                                                                 
                flags = [(sat.cleared and sat.sat not in dest_set) for sat in s.items]
-               # Find all contiguous cleared segments and record their start indices and lengths
-               segments = []  # list of (start_idx, length)
+                                                                                                
+               segments = []                               
                i = 0
                while i < len(flags):
                    if flags[i]:
@@ -819,38 +819,38 @@ class LiftPlannerV1P5:
                        i += 1
                if not segments:
                    continue
-               # Choose the largest segment by length; if tie, pick the shallowest (smallest start)
+                                                                                                   
                segments.sort(key=lambda x: (-x[1], x[0]))
                idx_large, run_len_large = segments[0]
-               # Only consider peeling if there is at least one blocker above the large run
+                                                                                           
                if idx_large > 0:
                    candidates_info.append((s, idx_large, run_len_large))
 
-           # 2) Compute approximate cost ratio for each candidate
+                                                                 
            cost_candidates: List[Tuple[float, int, Tuple]] = []
            for cand in candidates_info:
                stack_c, idx_large, run_len_large = cand
-               # Number of lifts needed to peel blockers above the large run
+                                                                            
                lifts_blockers = math.ceil(idx_large / self.hand_capacity)
-               # Number of lifts needed to deliver the large run
+                                                                
                lifts_goods = math.ceil(run_len_large / self.hand_capacity)
                actions = 2 * (lifts_blockers + lifts_goods)
                cost = actions / run_len_large if run_len_large > 0 else float('inf')
                cost_candidates.append((cost, idx_large, cand))
-           # Sort by cost then by shallower idx
+                                               
            cost_candidates.sort(key=lambda x: (x[0], x[1]))
            best_cost = cost_candidates[0][0] if cost_candidates else float('inf')
 
-           # 3) Determine top-run cleared and decide whether to deliver or peel
+                                                                               
            best_stack = None; best_run = 0
            for s in self.sources:
                run = self._contiguous_top_cleared(s)
                if run > best_run:
                    best_run = run; best_stack = s
-           # Compute cost of delivering top-run cleared (one pick and one drop) per cleared
+                                                                                           
            deliver_cost = (2 / best_run) if best_run > 0 else float('inf')
 
-           # 4) Decide: deliver top-run if cost is no worse than peeling; else peel
+                                                                                   
            if best_run > 0 and deliver_cost <= best_cost:
                take = min(best_run, self.hand_capacity, remaining)
                self._pick(best_stack, take, note=f"Mode B unified: pick {take} cleared from top")
@@ -859,31 +859,31 @@ class LiftPlannerV1P5:
                self.maybe_early_temp_return()
                continue
 
-           # 5) Otherwise, peel blockers from the best candidate based on largest run
+                                                                                     
            if not cost_candidates:
-               # No peel candidates and no deliverable top-run; end gracefully
+                                                                              
                break
            stack, idx, run_len = cost_candidates[0][2]
-           # Peel blockers only (no mixed pick), offload in one drop
+                                                                    
            chunk = min(self.hand_capacity, idx)
            if chunk <= 0:
                break
 
 
-           # Offload preference: SAFE SOURCE first (avoid stacks that contain cleared sats we will lift),
-           # then TEMP as fallback (making space if necessary).
-           needed_pred = remaining  # how many more cleared we plan to deliver
+                                                                                                         
+                                                               
+           needed_pred = remaining                                            
            future_set = self._predict_modeB_future_lift_set(needed_pred)
-           # Gather safe source candidates
+                                          
            safe_candidates = []
            for s in self.sources:
                if s is stack:
                    continue
                if len(s.items) + chunk > s.cap:
                    continue
-               # If this stack contains a cleared satellite we expect to lift later,
-               # allow offloading only when the total blockers above it (existing depth
-               # plus this offload chunk) stays below 7.  Otherwise skip this stack.
+                                                                                    
+                                                                                       
+                                                                                    
                future_idx = next(
                    (i for i, sat in enumerate(s.items) if sat.cleared and sat.sat in future_set),
                    None,
@@ -893,11 +893,11 @@ class LiftPlannerV1P5:
                safe_candidates.append(s)
            offload = None
            if safe_candidates:
-               # Choose the best by offload scoring (prefers more space, deeper future targets)
+                                                                                               
                safe_candidates.sort(key=lambda ss: self._score_offload_stack(ss, min(self.hand_capacity, chunk)))
                offload = safe_candidates[0]
            else:
-               # Fallback to TEMP; create space if needed
+                                                         
                try:
                    if self.temp.space_left() < chunk:
                        self._ensure_temp_space(chunk)
@@ -906,10 +906,10 @@ class LiftPlannerV1P5:
                except Exception:
                    offload = None
            if offload is None:
-               # As absolute last resort, choose any allowed source (may incur future moves)
+                                                                                            
                offload = self._choose_offload_stack(chunk, exclude=stack)
                if offload is None:
-                   # If truly nowhere to go, end gracefully
+                                                           
                    break
            self._pick(stack, chunk, note="Mode B unified: peel blockers")
            self._drop(offload, chunk, note=f"Mode B unified: offload to {offload.name}")
@@ -927,10 +927,10 @@ def _parse_bool(x: Any) -> bool:
 def read_stack_csv(path: Path, name: str) -> StackState:
    df = pd.read_csv(path)
    df.columns = [c.strip().lower() for c in df.columns]
-   # Support either a 'sat' or 'sat_id' column for satellite identifiers
-   # Normalise column names to ensure both variants are accepted
+                                                                        
+                                                                
    if 'sat' not in df.columns:
-       # Accept 'sat_id' as an alternative to 'sat'
+                                                   
        if 'sat_id' in df.columns:
            df['sat'] = df['sat_id']
        else:
@@ -938,7 +938,7 @@ def read_stack_csv(path: Path, name: str) -> StackState:
    for c in ["filled","interim","final","issue"]:
        if c not in df.columns:
            raise ValueError(f"CSV {path} missing required column '{c}'")
-   # Drop any unnamed columns (common when saving from spreadsheets)
+                                                                    
    drop_cols = [c for c in df.columns if c.startswith('unnamed')]
    df = df.drop(columns=drop_cols, errors='ignore')
    items: List[Sat] = []
@@ -950,9 +950,9 @@ def read_stack_csv(path: Path, name: str) -> StackState:
            final=_parse_bool(row["final"]),
            issue=_parse_bool(row["issue"]),
        ))
-   # Set stack capacity to accommodate the initial number of items or the default of 15, whichever is larger.
-   # This prevents capacity-related errors when returning blockers to the source stack for datasets
-   # that have more than 15 satellites in a location.
+                                                                                                             
+                                                                                                   
+                                                     
    cap_size = max(15, len(items))
    return StackState(name=name, items=items, cap=cap_size)
 


### PR DESCRIPTION
## Summary
- Strip all inline and block comments from `Lift_planner_v1p5a` for cleaner code

## Testing
- `python -m py_compile Lift_planner_v1p5a run_lift_plan_from_csv_v1p5a.py`


------
https://chatgpt.com/codex/tasks/task_e_68c60b64e098832dabf64a98e56f8d54