### PR TITLE
Raise error when insufficient cleared sats for stack

### DIFF
--- a/lift_planner_v1p5a.py
+++ b/lift_planner_v1p5a.py
@@ -718,6 +718,9 @@ class LiftPlannerV1P5:
         Strategy: deliver top-run cleared when present; otherwise peel blockers from the stack
         with the shallowest next-cleared target, offloading to a safe source or TEMP.
         """
+        total_cleared = sum(1 for s in self.sources for sat in s.items if sat.cleared)
+        if total_cleared < count:
+            raise ValueError("not enough cleared sats for a stack")
         self._mode_B_active = True
         delivered = len([x for x in self.dest.items if x.cleared])
         while delivered < count:


### PR DESCRIPTION
## Summary
- ensure Mode B fails fast if fewer cleared sats than requested

## Testing
- `python run_lift_plan_from_csv_v1p5a.py --mode B --count 36 --csv stack1.csv stack2.csv stack3.csv stack4.csv` *(fails: not enough cleared sats for a stack)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dc44b058832db3b555dd77301dcb