### PR TITLE
Log Mode B errors in CSV output

### DIFF
--- a/lift_planner_v1p5a.py
+++ b/lift_planner_v1p5a.py
@@ -855,3 +855,28 @@ def run_mode_A_with_failsafe_csv(planner: LiftPlannerV1P5, csv_path: Path, compa
         except Exception as write_err:
             status += f"; additionally failed to write CSV: {write_err}"
     return status
+
+
+def run_mode_B_with_failsafe_csv(planner: LiftPlannerV1P5, count: int, csv_path: Path, compact: bool = True) -> str:
+    """Run Mode B planning and always emit a CSV of the moves seen so far.
+
+    If an exception occurs during planning, the error message is appended to the
+    planner log so that it appears in the CSV output.  The function returns a
+    status string ("success" or the exception message).
+    """
+    try:
+        planner.plan_mode_B(count=count)
+        status = "success"
+    except Exception as e:
+        status = f"failure: {e}"
+        # Record the error in the planner log so the CSV captures it
+        try:
+            planner._record("error", "", 0, [], note=str(e))
+        except Exception:
+            pass
+    finally:
+        try:
+            planner.save_log_to_csv(csv_path, compact=compact)
+        except Exception as write_err:
+            status += f"; additionally failed to write CSV: {write_err}"
+    return status


### PR DESCRIPTION
## Summary
- Add `run_mode_B_with_failsafe_csv` helper to always write a CSV log and capture any Mode B errors in the log

## Testing
- `python -m py_compile lift_planner_v1p5a.py`
- `python - <<'PY'
from lift_planner_v1p5a import StackState, LiftPlannerV1P5, run_mode_B_with_failsafe_csv
from pathlib import Path
s1=StackState('S1', [])
s2=StackState('S2', [])
s3=StackState('S3', [])
s4=StackState('S4', [])
temp=StackState('Temp', [], cap=15)
dest=StackState('Dest', [], cap=100)
planner=LiftPlannerV1P5([s1,s2,s3,s4], temp, dest)
planner.plan_mode_B=lambda count: (_ for _ in ()).throw(RuntimeError('boom'))
status=run_mode_B_with_failsafe_csv(planner, count=28, csv_path=Path('test_actions.csv'))
print('status:', status)
import pandas as pd
print(pd.read_csv('test_actions.csv'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c6e2de5afc832dac602d687e4968ca