### PR TITLE
Fix drop order to maintain satellite stack orientation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/lift_planner_v1p5a.py
+++ b/lift_planner_v1p5a.py
@@ -672,7 +672,7 @@ class LiftPlannerV1P5:
                 raise AssertionError("Unified mode: must drop all lifted sats in a single drop.")
         # Original safety checks
         assert 1 <= k <= len(self.hand), "Drop exceeds hand content."
-        batch_top_to_bottom = self.hand[-k:][::-1]
+        batch_top_to_bottom = self.hand[-k:]
         if stack is not self.dest:
             assert len(stack.items) + k <= stack.cap, f"Drop would exceed cap of {stack.name}"
             if stack is not self.temp and self._is_remaining_target(stack.top()):

--- a/tests/test_drop_order.py
+++ b/tests/test_drop_order.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from lift_planner_v1p5a import StackState, Sat, LiftPlannerV1P5
+
+
+def make_sat(id: str) -> Sat:
+    return Sat(id, True, True, True, False)
+
+
+def test_drop_preserves_order():
+    source = StackState('loc1', [make_sat('A'), make_sat('B'), make_sat('C'), make_sat('D')])
+    target = StackState('loc2', [])
+    temp = StackState('temp', [])
+    planner = LiftPlannerV1P5([source, target], temp, StackState('dest', []))
+    planner._pick(source, 4)
+    planner._drop(target, 4)
+    assert [sat.sat for sat in target.items] == ['A', 'B', 'C', 'D']


### PR DESCRIPTION
## Summary
- Ensure dropping satellites preserves pick order
- Add regression test for drop order and ignore cache directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c783dc8f50832d8df85d453efd016c